### PR TITLE
Use mkfs instead of mkfs_command (which uses qemu-img)

### DIFF
--- a/datastore/lvm/mkfs
+++ b/datastore/lvm/mkfs
@@ -74,7 +74,7 @@ set_up_datastore "$BASE_PATH" "$RESTRICTED_DIRS" "$SAFE_DIRS"
 LV_NAME="lv-one-${ID}"
 LVM_SOURCE="$DST_HOST:$VG_NAME.$LV_NAME"
 DEV="/dev/$VG_NAME/$LV_NAME"
-MKFS_COMMAND=$(mkfs_command "$DEV" "$FSTYPE")
+MKFS_COMMAND=$(mkfs -t "$FSTYPE" "$DEV")
 
 REGISTER_CMD=$(cat <<EOF
     set -e


### PR DESCRIPTION
This fixes a bug where image creation failes, because opennebula tries creating the filesystem using
qemu, and the appropriate sudo rule is not in place.

```
mkfs: Command "    set -e
sudo lvcreate -L5120M vg0 -n lv-one-1
if [ -n "qemu-img create -f raw /dev/vg0/lv-one-1 0M" ]; then
sudo qemu-img create -f raw /dev/vg0/lv-one-1 0M
sudo: no tty present and no askpass program specified
Error registering host:/dev/vg0/lv-one-1
ExitCode: 1
```

It should not be necessary to run `qemu-img` anway, as the lv is already existent and we only need
to create the requested filesystem. This can be done with `/sbin/mkfs` (sudo rule already in place).